### PR TITLE
Fix color indicator width in thread picker

### DIFF
--- a/frontend/src/components/SelectKitThreadInput.vue
+++ b/frontend/src/components/SelectKitThreadInput.vue
@@ -175,6 +175,7 @@ export default defineComponent({
 .kit-thread-variant-color-box {
   outline: $input-field-border;
   border-radius: 5px;
+  min-width: 10px;
   width: 10px;
   height: 10px;
   margin: 3px 6px 3px 6px;


### PR DESCRIPTION
![image](https://github.com/Osardio/ThreadMaster/assets/37111027/eef20ffa-98e3-4cb4-a2a9-7f960421e0f4)
